### PR TITLE
Update production.rb for mail

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,9 +60,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
-
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {
   #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
@@ -90,4 +87,19 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp-relay.brevo.com",
+    port: 587,
+    user_name: ENV["BREVO_USERNAME"],
+    password: ENV["BREVO_SMTP_KEY"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
+
+  config.action_mailer.default_url_options = {
+    host: "blueprint-wcws.onrender.com/",
+    protocol: "https"
+  }
 end


### PR DESCRIPTION
## ✉️ Add Transactional Email Support with Brevo SMTP

### Summary

Configured transactional email delivery using [Brevo (formerly Sendinblue)](https://www.brevo.com/) for production environments.

### Changes

- Configured `config/environments/production.rb` to use Brevo's SMTP settings
- Added `BREVO_USERNAME` and `BREVO_SMTP_KEY` as environment variables in Render
- Set `default_url_options` for ActionMailer to match the Render production host

### Why

To enable production-ready email delivery for Devise features:
- Email confirmations
- Password reset instructions
- Password change notifications

### Testing

- Verified setup by signing up, resetting password, and checking Brevo’s Transactional Logs
