### PR TITLE
Add Pundit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,10 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
-gem 'sidekiq'
 gem "solid_cable"
+
+gem 'sidekiq'
+gem "redis", "~> 5.0"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -44,6 +46,7 @@ gem 'react-rails'
 gem 'haml-rails'
 gem 'devise'
 gem 'tailwindcss-rails', '~> 4.2'
+gem 'pundit'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -74,5 +77,3 @@ group :test do
   gem 'faker', '~> 2.15'
   gem 'mocha', '~> 2.0'
 end
-
-gem "tailwindcss-ruby", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,8 @@ GEM
     public_suffix (6.0.1)
     puma (6.6.0)
       nio4r (~> 2.0)
+    pundit (2.5.0)
+      activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (3.1.12)
     rack-session (2.1.0)
@@ -301,6 +303,8 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redis (5.4.0)
+      redis-client (>= 0.22.0)
     redis-client (0.24.0)
       connection_pool
     regexp_parser (2.10.0)
@@ -449,8 +453,10 @@ DEPENDENCIES
   propshaft
   pry-rails
   puma (>= 5.0)
+  pundit
   rails (~> 8.0.2)
   react-rails
+  redis (~> 5.0)
   rubocop-rails-omakase
   selenium-webdriver
   sidekiq
@@ -458,7 +464,6 @@ DEPENDENCIES
   solid_cache
   stimulus-rails
   tailwindcss-rails (~> 4.2)
-  tailwindcss-ruby (~> 4.0)
   thruster
   turbo-rails
   tzinfo-data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  include Pundit::Authorization
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   allow_browser versions: :modern
 
   before_action :configure_permitted_parameters, if: :devise_controller?
@@ -9,5 +11,17 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :email, :password, :password_confirmation])
     devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :email, :password, :password_confirmation, :current_password])
+  end
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+
+    if user_signed_in?
+      redirect_to authenticated_root_path
+    else
+      redirect_to unauthenticated_root_path
+    end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,3 +1,41 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   layout 'form_only'
+
+  before_action :authenticate_user!
+  before_action :set_user, only: [:update, :edit, :destroy]
+
+  def update
+    authorize @user
+
+    if update_user
+      redirect_to after_update_path_for(@user), notice: "Account updated."
+    else
+      clean_up_passwords(@user)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = resource
+  end
+
+  def update_user
+    if update_resource(@user, account_update_params)
+      send_password_change_notification_if_needed
+      bypass_sign_in(@user)
+      true
+    else
+      false
+    end
+  end
+
+  def send_password_change_notification_if_needed
+    @user.send_password_change_notification! if password_changed?
+  end
+
+  def password_changed?
+    account_update_params[:password].present?
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,51 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user  = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,5 @@
+class UserPolicy < ApplicationPolicy
+  def update?
+    user == record
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :user do
-    email { "user@example.com" }
+    email { Faker::Internet.unique.email }
     password { "Valid!123" }
     password_confirmation { "Valid!123" }
-    first_name { "John" }
-    last_name { "Doe" }
+    first_name { Faker::Name.first_name }
+    last_name  { Faker::Name.last_name }
     confirmed_at { Time.current }
   end
 end

--- a/test/integration/users/registrations_controller_test.rb
+++ b/test/integration/users/registrations_controller_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  VALID_PASSWORD = "Valid!123"
+  INVALID_PASSWORD = "WrongPassword!123"
+
+  def setup
+    Rails.application.reload_routes_unless_loaded
+
+    @user = create(:user, password: VALID_PASSWORD, password_confirmation: VALID_PASSWORD)
+    @other_user = create(:user, password: VALID_PASSWORD, password_confirmation: VALID_PASSWORD)
+    sign_in @user
+  end
+
+  def teardown
+    sign_out :user
+  end
+
+  test "allows user to update their own account" do
+    patch user_registration_path, params: {
+      user: {
+        current_password: VALID_PASSWORD,
+        first_name: "Updated",
+        password: "",
+        password_confirmation: ""
+      }
+    }
+
+    @user.reload
+    assert_equal "Updated", @user.first_name
+    assert_redirected_to authenticated_root_path
+  end
+
+  test "prevents user from updating own account with wrong current password" do
+    patch user_registration_path, params: {
+      user: {
+        current_password: INVALID_PASSWORD,
+        first_name: "ShouldNotChange",
+        password: "",
+        password_confirmation: ""
+      }
+    }
+
+    @user.reload
+    refute_equal "ShouldNotChange", @user.first_name
+    assert_response :unprocessable_entity
+    assert_match "Current password is invalid", response.body
+  end
+
+  test "prevents guest user from updating user account" do
+    sign_out :user
+  
+    patch user_registration_path, params: {
+      user: {
+        id: @user.id,
+        first_name: "Malicious",
+        current_password: VALID_PASSWORD
+      }
+    }
+  
+    @user.reload
+    refute_equal "Malicious", @user.first_name
+    assert_redirected_to new_user_session_path
+    assert_equal "You need to sign in or sign up before continuing.", flash[:alert]
+  end  
+end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class UserPolicyTest < ActiveSupport::TestCase
+  def setup
+    @user = create(:user)
+    @other_user = create(:user)
+  end
+
+  test "user can update their own account" do
+    assert UserPolicy.new(@user, @user).update?
+  end
+
+  test "user cannot update another user's account" do
+    refute UserPolicy.new(@user, @other_user).update?
+  end
+end


### PR DESCRIPTION
## Add Authorization and Tests for User Account Updates

### Changes
- Added Pundit for authorization
- Created `UserPolicy` to restrict account updates to the current user
- Integrated `authorize` checks into `Users::RegistrationsController#update`
- Included `Pundit::Authorization` in `ApplicationController`
- Implemented `rescue_from` to handle unauthorized access with redirect and flash
- Added controller tests for:
  - Updating own account successfully
  - Preventing update with wrong current password
  - Preventing guest user from updating any account

### Notes
- Ensured route loading for Devise mappings during test setup (https://github.com/heartcombo/devise/issues/5705)
- Used Faker in `User` factory for more realistic test data

### Why
To ensure users can only update their own account securely and add a solid foundation for authorization moving forward.
